### PR TITLE
Feature/add variable type registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ The following types are supported:
 
 ### Key alias (unreleased)
 
-By default the value for variable `FOO` should be provided by `ENV['FOO']`. Sometimes though it's convenient to let a different key provide the value, based on some runtime condition. A key-alias will let you do this.  
+By default the value for variable `FOO` should be provided by `ENV['FOO']`. Sometimes though it's convenient to let a different key provide the value, based on some runtime condition. A key-alias will let you do this.
 
 Consider for example local development where `REDIS_URL` differs between the development and test environment. Normally you'd prepare different shells with different values for `REDIS_URL`: one shell you can run tests in, and other shells where you'd run the console/server etc. This is cumbersome and easy to get wrong.
 
@@ -125,8 +125,8 @@ export REDIS_URL_TEST=redis://localhost:6379/1
 ```
 Now commands like `rails console` and `rails test` automatically point to the right redis database.
 
-Note that `ENV['REDIS_URL']` is still considered but `REDIS_URL_<key_alias>` takes precedence.  
-Also: any truthy value provided as key_alias is converted to an upcased string.  
+Note that `ENV['REDIS_URL']` is still considered but `REDIS_URL_<key_alias>` takes precedence.
+Also: any truthy value provided as key_alias is converted to an upcased string.
 Finally: this setting is optional.
 
 
@@ -150,10 +150,25 @@ $ DATABASE_URL_DEVELOPMENT=postgres://localhost/blog_development rails runner "p
 "postgres://localhost/blog_development"
 ```
 
-Note: this also works for `ENV.fetch('FOO')`.  
-Also: no coercion is done (like you would expect when accessing ENV-values directly).  
+Note: this also works for `ENV.fetch('FOO')`.
+Also: no coercion is done (like you would expect when accessing ENV-values directly).
 
 This means that for Rails applications when you set values for `DATABASE_URL_DEVELOPMENT` and `DATABASE_URL_TEST`, you no longer need a `config/database.yml`.
+
+
+#### Custom Types
+
+To defined your own type `#type` method can be used:
+
+```ruby
+# file: Envfile
+type :json do |raw_string|
+  JSON.parse(raw_string)
+end
+variable :CUSTOM_OPTIONS, :json
+```
+
+> NOTE: It is important to define any custom type before their usage. Otherwise you will get an `ArgumentError` exception.
 
 
 ### Groups
@@ -233,9 +248,9 @@ export DEPLOY_TOKEN=1234-ABC-5678
 
 ### let [direnv](https://direnv.net/) manage your environment
 
-[direnv](https://direnv.net/) will auto-(un)load values from `.envrc` when you switch folders.  
+[direnv](https://direnv.net/) will auto-(un)load values from `.envrc` when you switch folders.
 
-As a bonus it has some powerful commands in it's [stdlib](https://direnv.net/#man/direnv-stdlib.1).  
+As a bonus it has some powerful commands in it's [stdlib](https://direnv.net/#man/direnv-stdlib.1).
 For example:
 ```
 # this adds the project's bin-folder to $PATH
@@ -295,9 +310,9 @@ $ ./bin/heroku-env-check && git push live master
 
 ### What happened to default values??
 
-The short version: simplicity, i.e. the best tool for the job.  
+The short version: simplicity, i.e. the best tool for the job.
 
-In the early days of ENVied it was possible to provide default values for a variable.  
+In the early days of ENVied it was possible to provide default values for a variable.
 While convenient, it had several drawbacks:
 - it would introduce a value for ENVied.FOO, while ENV['FOO'] was nil: confusing and a potential source of bugs.
 - it hides the fact that an application can actually be configged via the environment.

--- a/envied.gemspec
+++ b/envied.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.4"
 
-  spec.add_dependency "thor", "~> 0.20"
+  spec.add_dependency "thor", "<= 2.0"
 
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "pry", "~> 0.12"

--- a/lib/envied.rb
+++ b/lib/envied.rb
@@ -4,6 +4,7 @@ require 'envied/env_proxy'
 require 'envied/coercer'
 require 'envied/coercer/envied_string'
 require 'envied/variable'
+require 'envied/type'
 require 'envied/configuration'
 require 'envied/env_interceptor'
 

--- a/lib/envied/coercer.rb
+++ b/lib/envied/coercer.rb
@@ -1,5 +1,9 @@
+require 'forwardable'
+
 # Responsible for all string to type coercions.
 class ENVied::Coercer
+  extend Forwardable
+  SUPPORTED_TYPES = [:env, :hash, :array, :time, :date, :symbol, :boolean, :integer, :string, :uri, :float].sort
 
   UnsupportedCoercion = Class.new(StandardError)
 
@@ -14,16 +18,36 @@ class ENVied::Coercer
   #
   # @return [type] the coerced string.
   def coerce(string, type)
-    unless supported_type?(type)
+    if self.class.built_in_type?(type)
+      coercer.public_send("to_#{type.downcase}", string)
+    elsif self.class.custom_type?(type)
+      custom_types[type].coerce(string)
+    else
       raise ArgumentError, "The type `#{type.inspect}` is not supported."
     end
-    coercer.public_send("to_#{type.downcase}", string)
+  end
+
+  def self.built_in_type?(type)
+    SUPPORTED_TYPES.include?(type)
+  end
+
+  def self.custom_type?(type)
+    custom_types.key?(type)
+  end
+
+  # Custom types container.
+  #
+  # @example
+  #   ENVied::Coercer.custom_types[:json] =
+  #     ENVied::Type.new(:json, ->(str) { JSON.parse(str) })
+  #
+  # @return
+  def self.custom_types
+    @custom_types ||= {}
   end
 
   def self.supported_types
-    @supported_types ||= begin
-      [:env, :hash, :array, :time, :date, :symbol, :boolean, :integer, :string, :uri, :float].sort
-    end
+    SUPPORTED_TYPES + custom_types.keys
   end
 
   # Whether or not Coercer can coerce strings to the provided type.
@@ -36,8 +60,11 @@ class ENVied::Coercer
   #
   # @return [Boolean] whether type is supported.
   def self.supported_type?(type)
-    supported_types.include?(type.to_sym.downcase)
+    name = type.to_sym.downcase
+    built_in_type?(name) || custom_type?(name)
   end
+
+  def_delegators :'self.class', :supported_type?, :supported_types, :custom_types
 
   def supported_type?(type)
     self.class.supported_type?(type)

--- a/lib/envied/configuration.rb
+++ b/lib/envied/configuration.rb
@@ -1,5 +1,7 @@
 class ENVied
   class Configuration
+    DEFAULT_TYPE = :string
+
     attr_reader :current_group, :coercer
 
     def initialize(**options, &block)
@@ -27,12 +29,16 @@ class ENVied
       end
     end
 
-    def variable(name, type = :string, **options)
+    def variable(name, type = DEFAULT_TYPE, **options)
       unless coercer.supported_type?(type)
         raise ArgumentError, "#{type.inspect} is not a supported type. Should be one of #{coercer.supported_types}"
       end
       options[:group] = current_group if current_group
       variables << ENVied::Variable.new(name, type, options)
+    end
+
+    def type(name, &block)
+      coercer.custom_types[name] = Type.new(name, block)
     end
 
     def group(*names, &block)

--- a/lib/envied/env_proxy.rb
+++ b/lib/envied/env_proxy.rb
@@ -19,7 +19,9 @@ class ENVied
     end
 
     def [](name)
-      coerce(variables_by_name[name.to_sym])
+      variable = variables_by_name[name.to_sym]
+      raise ArgumentError, "No variable #{name} is defined" unless variable
+      coerce(variable)
     end
 
     def has_key?(name)

--- a/lib/envied/type.rb
+++ b/lib/envied/type.rb
@@ -1,0 +1,22 @@
+class ENVied::Type
+  attr_reader :name
+
+  def initialize(name, coercer)
+    @name = name
+    @coercer = coercer
+  end
+
+  def coerce(value)
+    coercer.call(value)
+  end
+
+  def ==(other)
+    self.class == other.class &&
+      name == other.name &&
+      coercer == other.coercer
+  end
+
+  protected
+
+  attr_reader :coercer
+end

--- a/spec/coercer_spec.rb
+++ b/spec/coercer_spec.rb
@@ -270,5 +270,21 @@ RSpec.describe ENVied::Coercer do
         expect(coerce('https://www.google.com', :uri).host).to eq 'www.google.com'
       end
     end
+
+    describe 'to custom type' do
+      before do
+        coercer.custom_types[:json] =
+          ENVied::Type.new(
+            :json,
+            lambda do |raw_string|
+              JSON.parse(raw_string)
+            end
+          )
+      end
+
+      it 'converts strings to defined custom type' do
+        expect(coerce('{"a": 2}', :json)).to eq("a" => 2)
+      end
+    end
   end
 end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -1,6 +1,42 @@
 RSpec.describe ENVied::Configuration do
   it { is_expected.to respond_to :variable }
   it { is_expected.to respond_to :group }
+  it { is_expected.to respond_to :enable_defaults! }
+  it { is_expected.to respond_to :type }
+
+  describe '#variable' do
+    subject { config.variables }
+
+    context "with type" do
+      let(:config) do
+        described_class.new do
+          variable :foo, :boolean
+        end
+      end
+
+      it { is_expected.to include(ENVied::Variable.new(:foo, :boolean)) }
+    end
+
+    describe "with default" do
+      let(:config) do
+        described_class.new do
+          variable :bar, default: 'bar'
+        end
+      end
+
+      it { is_expected.to include(ENVied::Variable.new(:bar, :string, default: 'bar')) }
+    end
+
+    describe 'without type' do
+      let(:config) do
+        described_class.new do
+          variable :bar
+        end
+      end
+
+      it { is_expected.to include(ENVied::Variable.new(:bar, :string)) }
+    end
+  end
 
   def with_envfile(**options, &block)
     @config = ENVied::Configuration.new(options, &block)
@@ -16,12 +52,12 @@ RSpec.describe ENVied::Configuration do
       expect(config.variables).to include ENVied::Variable.new(:foo, :boolean, group: :default)
     end
 
-    it 'sets string as default type when no type is given' do
+    it 'sets a default value when specified' do
       with_envfile do
-        variable :bar
+        variable :bar, default: 'bar'
       end
 
-      expect(config.variables).to include ENVied::Variable.new(:bar, :string, default: nil, group: :default)
+      expect(config.variables).to include ENVied::Variable.new(:bar, :string, default: 'bar', group: :default)
     end
 
     it 'sets a default value when specified' do
@@ -53,6 +89,22 @@ RSpec.describe ENVied::Configuration do
         ENVied::Variable.new(:DISABLE_PRY, :boolean, default: 'false', group: :development),
         ENVied::Variable.new(:DISABLE_PRY, :boolean, default: 'false', group: :test)
       ]
+    end
+  end
+
+  describe '#type' do
+    subject { config.coercer.custom_types }
+
+    let(:coercer) { ->(raw_string) { Integer(raw_string) ** 2 } }
+    let(:config) do
+      block = coercer
+      described_class.new do
+        type(:power_integer, &block)
+      end
+    end
+
+    it 'creates type with given coercing block' do
+      is_expected.to include(power_integer: ENVied::Type.new(:power_integer, coercer))
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,4 +16,8 @@ RSpec.configure do |config|
   end
 
   config.order = :random
+
+  config.before do
+    ENVied::Coercer.custom_types.clear
+  end
 end


### PR DESCRIPTION
- allow registering custom types
- add `ENVied.[]` which avoids `#method_missing` invocation; it raises `ArgumentError` if given variable is not defined